### PR TITLE
typo in some example headers

### DIFF
--- a/docs/source/examples/cell
+++ b/docs/source/examples/cell
@@ -7,7 +7,7 @@
 #^cell_cycle_state: the Cell Cycle state in which this Cell is found as measured with the Fucci system. This column can contain one of the following values: G1, S, G2 or M.
 #^cell_volume: the volume of this Cell expressed in micron^3.
 #additional_tables: 4dn_FOF-CT_core, 4dn_FOF-CT_rna, 4dn_FOF-CT_trace
-#columns=(Cell_ID, Extra_Cell_ROI_ID, RNA_A_nr, RNA_B_nr, cell_cycle_state, cell_volume)
+##columns=(Cell_ID, Extra_Cell_ROI_ID, RNA_A_nr, RNA_B_nr, cell_cycle_state, cell_volume)
 1, 1, 10, 22, 1041.5, 12354.24, G1, 13453
 2, 1, 0, 11, 2041.3, 32234.24, G2, 35545
 3, 2, 10, 33, 101.5, 12354.24, S, 10010

--- a/docs/source/examples/extracell
+++ b/docs/source/examples/extracell
@@ -6,7 +6,7 @@
 #^Cell_B_nr: the number of identified Cells of type B identified to belong to this extracellular ROI.
 #^ROI_volume: the volume of this extracellular ROI expressed in micron^3.
 #additional_tables: 4dn_FOF-CT_core, 4dn_FOF-CT_rna, 4dn_FOF-CT_trace
-#columns=(Extra_Cell_ROI, Cell_A_nr, Cell_B_nr, ROI_volume)
+##columns=(Extra_Cell_ROI, Cell_A_nr, Cell_B_nr, ROI_volume)
 1, 10, 22, 13453
 2, 0, 11, 35545
 3, 10, 33, 10010

--- a/docs/source/examples/mapping
+++ b/docs/source/examples/mapping
@@ -7,7 +7,7 @@
 #^ROI_volume: the volume of this ROI expressed in micron^3.
 #^ROI_intensity: the integrated average signal intensity measured within the boundaries of this ROI, of the marker used to identify this nuclear feature.
 #additional_tables: 4dn_FOF-CT_core, 4dn_FOF-CT_rna, 4dn_FOF-CT_trace
-#columns=(Sub_Cell_ROI_ID, ROI_boundaries, ROI_volume, ROI_intensity)
+##columns=(Sub_Cell_ROI_ID, ROI_boundaries, ROI_volume, ROI_intensity)
 1, (0,0 1,2 3,5)
 2, (0,0 2,3 4,6)
 3, (0,0 3,2 7,5)

--- a/docs/source/examples/subcell
+++ b/docs/source/examples/subcell
@@ -6,7 +6,7 @@
 #^ROI_volume: the volume of this ROI expressed in micron^3.
 #^ROI_intensity: the integrated average signal intensity of the marker of interest as measured within the boundaries of this ROI.
 #additional_tables: 4dn_FOF-CT_core, 4dn_FOF-CT_rna, 4dn_FOF-CT_trace
-#columns=(Sub_Cell_ROI_ID, Cell_ID, ROI_volume, ROI_intensity)
+##columns=(Sub_Cell_ROI_ID, Cell_ID, ROI_volume, ROI_intensity)
 1, 1, 1345, 3500
 2, 1, 3554, 1500
 3, 2, 1001, 2500

--- a/docs/source/examples/trace
+++ b/docs/source/examples/trace
@@ -6,7 +6,7 @@
 #^RNA_A_intensity: This records the intensity of the nascent RNA A expression signal associated with this Trace.
 #^NL_distance: This field records the distance of this Trace to the Nuclear Lamina.
 #additional_tables: 4dn_FOF-CT_core, 4dn_FOF-CT_cell
-#columns=(Trace_ID, allele, RNA_A_int, NL_distance)
+##columns=(Trace_ID, allele, RNA_A_int, NL_distance)
 1, BL6, 43253, 0.235
 2, CAST, 40001, 0.563
 3, BL6, 1000, 0.135


### PR DESCRIPTION
Added a `#` in the `columns` header, in some example files, which was missing by mistake.